### PR TITLE
Add a SelectorProvider that reuses custom provider implementations.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/network/Selector.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/Selector.java
@@ -103,6 +103,7 @@ public class Selector implements Selectable, AutoCloseable {
     }
 
     private final Logger log;
+    private final java.nio.channels.spi.SelectorProvider selectorProvider;
     private final java.nio.channels.Selector nioSelector;
     private final Map<String, KafkaChannel> channels;
     private final Set<KafkaChannel> explicitlyMutedChannels;
@@ -157,7 +158,9 @@ public class Selector implements Selectable, AutoCloseable {
             MemoryPool memoryPool,
             LogContext logContext) {
         try {
-            this.nioSelector = java.nio.channels.Selector.open();
+            this.selectorProvider = SelectorProvider.provider();
+            this.nioSelector = selectorProvider.openSelector();
+
         } catch (IOException e) {
             throw new KafkaException(e);
         }
@@ -264,7 +267,7 @@ public class Selector implements Selectable, AutoCloseable {
     @Override
     public void connect(String id, InetSocketAddress address, int sendBufferSize, int receiveBufferSize) throws IOException {
         ensureNotRegistered(id);
-        SocketChannel socketChannel = SocketChannel.open();
+        SocketChannel socketChannel = selectorProvider.openSocketChannel();
         SelectionKey key = null;
         try {
             configureSocketChannel(socketChannel, sendBufferSize, receiveBufferSize);

--- a/clients/src/main/java/org/apache/kafka/common/network/SelectorProvider.java
+++ b/clients/src/main/java/org/apache/kafka/common/network/SelectorProvider.java
@@ -1,0 +1,28 @@
+package org.apache.kafka.common.network;
+
+
+public class SelectorProvider
+{
+    private static ThreadLocal<java.nio.channels.spi.SelectorProvider> selectorProviderHolder = new ThreadLocal<>();
+
+
+    public static void set(java.nio.channels.spi.SelectorProvider selectorProvider)
+    {
+        selectorProviderHolder.set(selectorProvider);
+    }
+
+
+    public static java.nio.channels.spi.SelectorProvider provider()
+    {
+        java.nio.channels.spi.SelectorProvider selectorProvider = selectorProviderHolder.get();
+
+        if (selectorProvider != null)
+        {
+            return selectorProvider;
+        }
+        else
+        {
+            return java.nio.channels.spi.SelectorProvider.provider();
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ group=org.apache.kafka
 #  - streams/quickstart/pom.xml
 #  - streams/quickstart/java/src/main/resources/archetype-resources/pom.xml
 #  - streams/quickstart/java/pom.xml
-version=3.9.0
+version=3.9.0.SEE1
 scalaVersion=2.13.14
 # Adding swaggerVersion in gradle.properties to have a single version in place for swagger
 # New version of Swagger 2.2.14 requires minimum JDK 11.


### PR DESCRIPTION
### Tasks:
- [x] Add a custom [SelectorProvider](clients/src/main/java/org/apache/kafka/common/network/SelectorProvider.java).
- [x] Update [Selector](clients/src/main/java/org/apache/kafka/common/network/Selector.java) to utilize the custom SelectorProvider.

### Changes:
The [SelectorProvider](clients/src/main/java/org/apache/kafka/common/network/SelectorProvider.java) fixes an issue where the static method `Selector.open()` would create a system-wide default SelectorProvider object whereas in our case we need a custom SelectorProvider.
This implementation utilizes ThreadLocal so that each thread can reuse the configured provider within its' own context.

The [Selector](clients/src/main/java/org/apache/kafka/common/network/Selector.java) code is updated to use our custom SelectorProvider from `org.apache.kafka.common.network`.